### PR TITLE
Add utility function for extracting string from error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,12 @@ import { resultFromTruthy } from './util';
 import BrowserWallet from './BrowserWallet';
 import { usePiggybank } from './usePiggybank';
 import { refreshPiggybankState, PiggybankState } from './state';
+import { errorString } from './error';
 
 const rpc = new JsonRpcClient(new HttpProvider(TESTNET.jsonRpcUrl));
 
 function refreshContract(index: bigint, setContract: React.Dispatch<Info | undefined>) {
+    // TODO Store and display error instead of just logging it.
     refresh(rpc, index).then(setContract).catch(console.error);
 }
 
@@ -55,7 +57,7 @@ export default function App(props: WalletConnectionProps) {
     const [piggybankState, setPiggybankState] = useState<Result<PiggybankState, string>>();
     useEffect(() => {
         resultFromTruthy(contract, 'no contract selected')
-            .asyncAndThen((c) => ResultAsync.fromPromise(refreshPiggybankState(rpc, c), (e) => (e as Error).message))
+            .asyncAndThen((c) => ResultAsync.fromPromise(refreshPiggybankState(rpc, c), errorString))
             .then(setPiggybankState);
     }, [contract]);
 

--- a/src/Contract.tsx
+++ b/src/Contract.tsx
@@ -4,6 +4,7 @@ import { Result, ResultAsync } from 'neverthrow';
 import { Alert, Button, Col, Form, Modal, Row, Spinner } from 'react-bootstrap';
 import { resultFromTruthy } from './util';
 import { refreshPiggybankState, PiggybankState } from './state';
+import { errorString } from './error';
 
 export interface Info {
     version: number;
@@ -47,7 +48,7 @@ export function ContractSelector(props: Props) {
         setIsLoading(true);
         resultFromTruthy(input, undefined)
             .andThen(parseContractIndex)
-            .asyncAndThen((index) => ResultAsync.fromPromise(refresh(rpc, index), (e) => (e as Error).message))
+            .asyncAndThen((index) => ResultAsync.fromPromise(refresh(rpc, index), errorString))
             .match<[Info?, string?]>(
                 (c) => [c, undefined],
                 (e) => [undefined, e]
@@ -105,7 +106,7 @@ export function ContractManager(props: ModalProps) {
     const [currentPiggybankState, setCurrentPiggybankState] = useState<Result<PiggybankState, string>>();
     useEffect(() => {
         resultFromTruthy(currentContract, 'no contract selected')
-            .asyncAndThen((c) => ResultAsync.fromPromise(refreshPiggybankState(rpc, c), (e) => (e as Error).message))
+            .asyncAndThen((c) => ResultAsync.fromPromise(refreshPiggybankState(rpc, c), errorString))
             .then(setCurrentPiggybankState);
     }, [rpc, currentContract]);
 

--- a/src/WalletConnect2.tsx
+++ b/src/WalletConnect2.tsx
@@ -3,6 +3,7 @@ import { WalletConnectConnection, WalletConnection } from '@concordium/react-com
 import { useEffect, useState } from 'react';
 import { Result, ResultAsync } from 'neverthrow';
 import { PING_INTERVAL_MS } from './config';
+import { errorString } from './error';
 
 interface Props {
     connection: WalletConnection | undefined;
@@ -16,7 +17,7 @@ export default function WalletConnect2({ connection }: Props) {
             // Set up ping loop.
             const interval = setInterval(() => {
                 const start = Date.now();
-                ResultAsync.fromPromise(connection.ping(), (e) => (e as Error).message)
+                ResultAsync.fromPromise(connection.ping(), errorString)
                     .map(() => Date.now() - start)
                     .then(setPingDurationMs);
             }, PING_INTERVAL_MS);

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,3 @@
+export function errorString(err: any): string {
+    return (err as Error).message || (err as string);
+}

--- a/src/usePiggybank.ts
+++ b/src/usePiggybank.ts
@@ -6,6 +6,7 @@ import { TESTNET } from './config';
 import { Info } from './Contract';
 import { resultFromTruthy } from './util';
 import { submitDeposit, submitSmash } from './transaction';
+import { errorString } from './error';
 
 export function usePiggybank(
     connection: WalletConnection | undefined,
@@ -24,7 +25,7 @@ export function usePiggybank(
                 .asyncAndThen(([client, account, contract]) =>
                     ResultAsync.fromPromise(
                         submitDeposit(client, new CcdAmount(amount), account, contract),
-                        (e) => (e as Error).message
+                        errorString
                     )
                 )
                 .map((txHash) => {
@@ -45,7 +46,7 @@ export function usePiggybank(
                 resultFromTruthy(contract, 'no contract'),
             ])
                 .asyncAndThen(([client, account, contract]) =>
-                    ResultAsync.fromPromise(submitSmash(client, account, contract), (e) => (e as Error).message)
+                    ResultAsync.fromPromise(submitSmash(client, account, contract), errorString)
                 )
                 .map((txHash) => {
                     console.debug(`${TESTNET.ccdScanBaseUrl}/?dcount=1&dentity=transaction&dhash=${txHash}`);


### PR DESCRIPTION
## Purpose

Ensure that non-`Error` exceptions don't go undetected.

## Changes

Compared to the usual strategy of using `(err as Error).message`, this function adds a fallback to just treating the value as a string. This avoids errors that aren't actually of type `Error` to be masked as described in https://concordium.atlassian.net/browse/CBW-780.

This is essentially the same change as https://github.com/Concordium/concordium-dapp-libraries/pull/17 in the dApp libs.