### PR TITLE
Add link to piggy bank tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Unreleased changes
+
+## 0.3.0
+
+-   Add link to piggy bank tutorial
+
+## 0.2.0
+
+-   Initial piggy bank front end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "piggybank",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "dependencies": {
         "@concordium/react-components": "^0.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import BrowserWallet from './BrowserWallet';
 import { usePiggybank } from './usePiggybank';
 import { refreshPiggybankState, PiggybankState } from './state';
 import { errorString } from './error';
+import packageInfo from '../package.json';
 
 const rpc = new JsonRpcClient(new HttpProvider(TESTNET.jsonRpcUrl));
 
@@ -162,6 +163,15 @@ export default function App(props: WalletConnectionProps) {
                     )}
                 </Col>
             </Row>
+            <hr />
+            Version: {packageInfo.version} |{' '}
+            <a
+                href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/piggy-bank/index.html"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Explore the piggy bank tutorial here.
+            </a>
         </Container>
     );
 }


### PR DESCRIPTION
## Purpose

All hosted front ends should have a way to find the source code easily. Either through a link to an associated tutorial (that contains links to the source code) or if no tutorial exists through a link to the source code.

## Changes

- Add link to tutorial.
- Add `ChangeLog`.
- Add `version` to front end.
