### PR TITLE
Migrate use of 'JsonRpcClient' to 'useGrpcClient'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
-## Unreleased changes
+# Changelog
 
-## 0.3.0
+All notable changes to this project will be documented in this file.
 
--   Add link to piggy bank tutorial
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0
+## [Unreleased]
 
--   Initial piggy bank front end
+### Changed
+
+-   Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
+
+## [0.3.0]
+
+-   Add link to piggy bank tutorial.
+
+## [0.2.0]
+
+-   Initial piggy bank front end.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "dependencies": {
         "@concordium/react-components": "^0.3.0",
-        "@concordium/web-sdk": "^3.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/src/Contract.tsx
+++ b/src/Contract.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { AccountAddress, CcdAmount, JsonRpcClient } from '@concordium/web-sdk';
+import { AccountAddress, CcdAmount, ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { Result, ResultAsync } from 'neverthrow';
 import { Alert, Button, Col, Form, Modal, Row, Spinner } from 'react-bootstrap';
 import { resultFromTruthy } from './util';
@@ -17,11 +17,11 @@ export interface Info {
 
 interface Props {
     children: React.ReactNode;
-    rpc: JsonRpcClient;
+    rpc: ConcordiumGRPCClient;
     setContract: React.Dispatch<Info | undefined>;
 }
 
-export async function refresh(rpc: JsonRpcClient, index: bigint) {
+export async function refresh(rpc: ConcordiumGRPCClient, index: bigint) {
     console.debug(`Refreshing info for contract ${index.toString()}`);
     const info = await rpc.getInstanceInfo({ index, subindex: BigInt(0) });
     if (!info) {
@@ -93,7 +93,7 @@ export function ContractSelector(props: Props) {
 }
 
 interface ModalProps {
-    rpc: JsonRpcClient;
+    rpc: ConcordiumGRPCClient;
     contract: Info | undefined;
     setContract: React.Dispatch<Info | undefined>;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-import { JsonRpcClient, toBuffer } from '@concordium/web-sdk';
+import { ConcordiumGRPCClient, toBuffer } from '@concordium/web-sdk';
 import { Buffer } from 'buffer/';
 import { microCcdToCcdString } from './amount';
 import { Info } from './Contract';
@@ -11,7 +11,7 @@ export interface PiggybankState {
     queryTime: Date;
 }
 
-export async function refreshPiggybankState(rpc: JsonRpcClient, contract: Info) {
+export async function refreshPiggybankState(rpc: ConcordiumGRPCClient, contract: Info) {
     console.debug(`Refreshing piggybank state for contract ${contract.index.toString()}`);
     const { version, name, index, methods } = contract;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,22 +1086,6 @@
   dependencies:
     "@concordium/web-sdk" "^3.4.2"
 
-"@concordium/common-sdk@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@concordium/common-sdk/-/common-sdk-6.2.0.tgz#bf62ae229ee81027be2928d054f33a20b5261af6"
-  integrity sha512-7GVYN9tRXUdf8OP37lCWco7FfnPx0wYeh+VvGyw91wQmYpPlltsy7w5GwFzAmh6ooVU6tHY+uncU3TaG/pv0gw==
-  dependencies:
-    "@concordium/rust-bindings" "0.9.0"
-    "@noble/ed25519" "^1.7.1"
-    "@scure/bip39" "^1.1.0"
-    bs58check "^2.1.2"
-    buffer "^6.0.3"
-    cross-fetch "3.1.5"
-    hash.js "^1.1.7"
-    iso-3166-1 "^2.1.1"
-    json-bigint "^1.0.0"
-    uuid "^8.3.2"
-
 "@concordium/common-sdk@6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@concordium/common-sdk/-/common-sdk-6.5.0.tgz#e5b04d3016f2fdcdcdad08c9fb51ebdd7bf0a774"
@@ -1132,11 +1116,6 @@
   resolved "https://registry.yarnpkg.com/@concordium/rust-bindings/-/rust-bindings-0.11.1.tgz#bcd3313cf650a054bde6195e66ad2632a648ef80"
   integrity sha512-FElhfj5LhsL+xCVsg1Gj9T2FhDVq/HmTCCPg9Np2MW5AlXccYI1FXLtO7Lchv83GexnKu/w2q3LqbOrKO19r6Q==
 
-"@concordium/rust-bindings@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@concordium/rust-bindings/-/rust-bindings-0.9.0.tgz#366904e278f0f1fe17b46793f6291fba2b59c97d"
-  integrity sha512-LaYABqQH5j9FBZRnI296nHTN9/f4GveeisMtCm4LYXvA8E/YLhc7pxV3qbRqTevNcH8WcVmJhz6GK8b3lV5b7Q==
-
 "@concordium/wallet-connectors@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@concordium/wallet-connectors/-/wallet-connectors-0.3.1.tgz#38cca33cffd1fa9ef9e986a6eb52b8c01d5be70f"
@@ -1145,16 +1124,6 @@
     "@concordium/browser-wallet-api-helpers" "^2.5.0"
     "@walletconnect/qrcode-modal" "^1.8.0"
     "@walletconnect/sign-client" "^2.1.4"
-
-"@concordium/web-sdk@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@concordium/web-sdk/-/web-sdk-3.2.0.tgz#a16980c789cf4b38528f47e3cc40ed1b38c79594"
-  integrity sha512-gaGh8+PsdRLwRbm4KJhCPB0rNug+6W0Yx6VLgcDSLttTPqAos4drGY0/l6A+mqz+yMb8icvoMIB4U6895eF5aw==
-  dependencies:
-    "@concordium/common-sdk" "6.2.0"
-    "@concordium/rust-bindings" "0.9.0"
-    buffer "^6.0.3"
-    process "^0.11.10"
 
 "@concordium/web-sdk@^3.4.2":
   version "3.5.0"


### PR DESCRIPTION
## Purpose

Migrate deprecated v1 client.

## Changes

Replace construction of `JsonRpcClient` by `useGrpcClient` and handle the (possibly never happening) case of it being non-present.